### PR TITLE
cross-compile to scala 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       matrix:
         scala:
-          - 2.13.5
-          - 2.12.13
+          - 2.13.14
+          - 3.3.3
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
         scala:
           - 2.13.14
           - 3.3.3
+          - 2.12.18
 
     steps:
       - uses: actions/checkout@v2

--- a/build.sbt
+++ b/build.sbt
@@ -12,17 +12,31 @@ organizationName := "Evolution"
 
 organizationHomepage := Some(url("https://evolution.com"))
 
+crossScalaVersions := Seq("3.3.3", "2.13.12")
 scalaVersion := crossScalaVersions.value.head
 
-crossScalaVersions := Seq("2.13.12", "2.12.18")
+
+scalacOptions ++= {
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((3, _))  => Seq.empty
+    case Some((2, 13)) => Seq("-Xsource:3", "-Ytasty-reader")
+    case _             => Seq.empty
+  }
+}
+//see https://github.com/scodec/scodec/issues/365
+libraryDependencies ++= (CrossVersion.partialVersion(scalaVersion.value) match {
+  case Some((3, _)) =>
+    Seq(
+      Scodec.core % Optional
+    )
+  case _ =>
+    Seq(
+      Scodec.core2 % Optional
+    )
+})
+libraryDependencies ++= Seq(Akka.actor, scalatest % Test)
 
 publishTo := Some(Resolver.evolutionReleases)
-
-libraryDependencies ++= Seq(
-  Akka.actor,
-  Scodec.core,
-  Scodec.bits,
-  scalatest % Test)
 
 licenses := Seq(("MIT", url("https://opensource.org/licenses/MIT")))
 

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ scalaVersion := crossScalaVersions.value.head
 
 scalacOptions ++= {
   CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((3, _))  => Seq.empty
+    case Some((3, _))  => Seq("-Xsource-features:package-prefix-implicits")
     case Some((2, 13)) => Seq("-Xsource:3", "-Ytasty-reader")
     case _             => Seq.empty
   }

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ organizationName := "Evolution"
 
 organizationHomepage := Some(url("https://evolution.com"))
 
-crossScalaVersions := Seq("3.3.3", "2.13.14")
+crossScalaVersions := Seq("3.3.3", "2.13.14", "2.12.18")
 scalaVersion := crossScalaVersions.value.head
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ organizationName := "Evolution"
 
 organizationHomepage := Some(url("https://evolution.com"))
 
-crossScalaVersions := Seq("3.3.3", "2.13.12")
+crossScalaVersions := Seq("3.3.3", "2.13.14")
 scalaVersion := crossScalaVersions.value.head
 
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,12 +5,12 @@ object Dependencies {
   val scalatest = "org.scalatest" %% "scalatest" % "3.2.17"
 
   object Akka {
-    private val version = "2.6.8"
+    private val version = "2.6.21"
     val actor = "com.typesafe.akka" %% "akka-actor" % version
   }
 
   object Scodec {
-    val core = "org.scodec" %% "scodec-core" % "1.11.7"
-    val bits = "org.scodec" %% "scodec-bits" % "1.1.14"
+    val core = "org.scodec" %% "scodec-core" % "2.3.1"
+    val core2 = "org.scodec" %% "scodec-core" % "1.11.10"
   }
 }

--- a/src/main/scala/com/evolutiongaming/serialization/SerializedMsg.scala
+++ b/src/main/scala/com/evolutiongaming/serialization/SerializedMsg.scala
@@ -5,6 +5,7 @@ import akka.serialization.{Serialization, SerializationExtension, SerializerWith
 import scodec.bits.ByteVector
 import scodec.{Codec, codecs}
 
+import scala.annotation.nowarn
 import scala.util.Try
 
 /** Object serialized to a binary with the metadata allowing to decode it.
@@ -15,7 +16,7 @@ import scala.util.Try
 final case class SerializedMsg(identifier: Int, manifest: String, bytes: ByteVector)
 
 object SerializedMsg {
-
+  @nowarn("cat=scala3-migration")
   implicit val CodecSerializedMsg: Codec[SerializedMsg] = {
     val codec = codecs.int32 :: codecs.utf8_32 :: codecs.variableSizeBytes(codecs.int32, codecs.bytes)
     codec.as[SerializedMsg]

--- a/src/main/scala/com/evolutiongaming/serialization/SerializedMsg.scala
+++ b/src/main/scala/com/evolutiongaming/serialization/SerializedMsg.scala
@@ -16,7 +16,7 @@ import scala.util.Try
 final case class SerializedMsg(identifier: Int, manifest: String, bytes: ByteVector)
 
 object SerializedMsg {
-  @nowarn("cat=scala3-migration")
+  @nowarn("msg=package prefix of the required type")
   implicit val CodecSerializedMsg: Codec[SerializedMsg] = {
     val codec = codecs.int32 :: codecs.utf8_32 :: codecs.variableSizeBytes(codecs.int32, codecs.bytes)
     codec.as[SerializedMsg]


### PR DESCRIPTION

use different scodec versions for scala 2/3;
update akka to version that has been compiled to scala 3